### PR TITLE
Issue #71 implemented, scroll to first element of result upon fetching

### DIFF
--- a/main.js
+++ b/main.js
@@ -87,6 +87,7 @@ function search(e) {
           div.appendChild(textDiv);
           div.appendChild(imgDiv);
           document.getElementById("results").appendChild(div);
+          document.getElementById("results").scrollIntoView();
         }
       }
     },


### PR DESCRIPTION
### Description

I only made one change i.e. after the result is fetched and appended to container, window will automatically scroll to first element of results.

### Checklist

- [Yes] I am making a proper pull request, not spam.
- [Yes] I've checked the issue list before deciding what to submit.

## Related Issues or Pull Requests

Issue #71 

## Add relevant screenshot or video (if any)
Search:
![Web capture_3-10-2022_22132_127 0 0 1](https://user-images.githubusercontent.com/71081929/193632169-22172874-e87f-423b-b950-8457c6e60832.jpeg)
After search:
![Screenshot 2022-10-03 220255](https://user-images.githubusercontent.com/71081929/193632211-f000ba38-4958-4893-81f6-057578f4d314.png)
