### PR TITLE
Add two media-queries for small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   </nav>
   <header class="header" id="header">
     <img src="img/Man-Reading-a-Book-Vector-Illustration.svg" alt="Man Reading a Book" class="illustration" />
-    <h1 class="title" style="font-size: 7em">
+    <h1 class="title" style="font-size: 6em">
       Book
       <p class="finder" style="display: inline-block">Finder</p>
     </h1>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   </nav>
   <header class="header" id="header">
     <img src="img/Man-Reading-a-Book-Vector-Illustration.svg" alt="Man Reading a Book" class="illustration" />
-    <h1 class="title" style="font-size: 6em">
+    <h1 class="title">
       Book
       <p class="finder" style="display: inline-block">Finder</p>
     </h1>

--- a/style.css
+++ b/style.css
@@ -120,6 +120,13 @@ html {
 	width: 50%;
 	font-family: "Comfortaa", cursive;
 }
+
+@media only screen and (max-width: 400px) {
+	.search {
+		width: 90%;
+	}
+}
+
 .search-form{
 	background-color: var(--nav-color);
 	border-radius: 25px;
@@ -178,6 +185,12 @@ html {
 .illustration, .img-results {
 	margin: 5px auto;
 	width: 20%
+}
+
+@media only screen and (max-width: 400px) {
+	.illustration, .img-results {
+		width: 50%;
+	}
 }
 
 h1 {

--- a/style.css
+++ b/style.css
@@ -111,6 +111,12 @@ html {
 	color: var(--secondary-color);
 }
 
+@media only screen and (max-width: 400px) {
+	.title {
+		font-size: 6em;
+	}
+}
+
 .finder {
 	font-weight: lighter;
 }
@@ -189,7 +195,15 @@ html {
 
 @media only screen and (max-width: 400px) {
 	.illustration, .img-results {
-		width: 50%;
+		width: 70%;
+	}
+
+	.col-md-8 {
+		padding-bottom: 15px;
+	}
+
+	.col-md-8 h1 {
+		font-size: 1.75rem;
 	}
 }
 


### PR DESCRIPTION
### Description

Solution for the issue #162.

I've added a couple of media queries to slightly increase the image and search bar width and decrease the font-size for the heading on small screens. Now it fits without horizontal scrolling (see screenshot).

### Checklist

- [+] I am making a proper pull request, not spam.
- [+] I've checked the issue list before deciding what to submit.

## Related Issues or Pull Requests

[Issue](https://github.com/wasimreja/book-finder/issues/162)

## Add relevant screenshot or video (if any)

![Screenshot 2022-10-11 160817](https://user-images.githubusercontent.com/87036699/195114046-79fd44a9-828d-4ebd-8512-a955c18beb44.png)
