### PR TITLE
Added alt tag from the title of the book to each book image result

### DIFF
--- a/main.js
+++ b/main.js
@@ -74,6 +74,7 @@ function search(e) {
 
             const bookImage = document.createElement("img");
             bookImage.src = res.items[i].volumeInfo.imageLinks.smallThumbnail;
+            bookImage.alt = `${res.items[i].volumeInfo.title} book`;
             bookImage.classList.add("w-100");
 
             bookImageContainer.appendChild(bookImage);


### PR DESCRIPTION
### Description

I added alt tag based on the book title to the image for each result that came out of the search.
Alt attributes are important in terms of on-page optimization for two reasons:
- Alt text is displayed to visitors if any particular image cannot be loaded (or if the images are disabled).
- Alt attributes provide context because search engines can’t “see” images.

### Checklist

- [x] I am making a proper pull request, not spam.
- [x] I've checked the issue list before deciding what to submit.

## Related Issues or Pull Requests

Pull Request

## Add relevant screenshot or video (if any)

New:
![image](https://user-images.githubusercontent.com/26623057/195202288-7742a351-31f5-4971-96c7-25b9ea91a145.png)

Old:
![image](https://user-images.githubusercontent.com/26623057/195202471-1d9a0ba1-1d9a-4e6e-8b9b-8df8be745f08.png)

